### PR TITLE
Implement profile retrieval and editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Maven
+backend/target/
+
+# Node
+frontend/node_modules/
+
+# IDE
+.idea/
+*.iml
+
+# OS
+.DS_Store
+
+# Backup files
+*~
+
+# env files
+frontend/.env.local

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Team17 Bookstore
+
+This repository contains a Spring Boot backend and a Next.js frontend.
+
+## Backend
+
+Requirements: Java 17 and Maven. The backend expects a MySQL database called `bookstore` running on `localhost`.
+
+```
+cd backend
+./mvnw spring-boot:run
+```
+
+## Frontend
+
+Requirements: Node.js 18.
+
+```
+cd frontend
+npm install
+npm run dev
+```
+
+Create a `.env.local` file inside `frontend/` to configure the API base URL:
+
+```
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+```
+
+## Database
+
+Sample data can be loaded using the SQL script in `backend/src/main/resources/schema.sql`.
+
+User accounts are stored with hashed passwords. Use `/users/register` to create a new account and `/users/{id}` with PUT to edit profile data.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -51,18 +51,31 @@
 	  </dependency>
 
 	  <!-- Spring Boot Web -->
-	  <dependency>
+          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-	  </dependency>
+          </dependency>
+
+          <!-- Password hashing -->
+          <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+          </dependency>
 
 	  <!-- Spring Boot Test -->
-	  <dependency>
+          <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-	  </dependency>
-	</dependencies>
+          </dependency>
+
+          <!-- H2 for tests -->
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
 
 
 	<build>

--- a/backend/src/main/java/com/bookstore/team17bookstore/config/WebConfig.java
+++ b/backend/src/main/java/com/bookstore/team17bookstore/config/WebConfig.java
@@ -1,0 +1,30 @@
+package com.bookstore.team17bookstore.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOrigin("http://localhost:3000");
+        config.addAllowedMethod("*");
+        config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/bookstore/team17bookstore/model/User.java
+++ b/backend/src/main/java/com/bookstore/team17bookstore/model/User.java
@@ -19,9 +19,13 @@ public class User {
     private String email;
     private String phone;
     private String password;
+    private boolean promo;
+
+    private String address;
 
     //@Enumerated(EnumType.STRING)
     //private UserStatus status;
+    private String status;
     
     //@OneToOne(optional = true, cascade = CascadeType.ALL)
     //private Address address;
@@ -53,4 +57,13 @@ public class User {
 
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
+
+    public boolean isPromo() { return promo; }
+    public void setPromo(boolean promo) { this.promo = promo; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
 }

--- a/backend/src/main/java/com/bookstore/team17bookstore/repository/UserRepository.java
+++ b/backend/src/main/java/com/bookstore/team17bookstore/repository/UserRepository.java
@@ -13,7 +13,10 @@ public class UserRepository {
     private final DataSource dataSource;
 
     private static final String INSERT =
-        "INSERT INTO users (name, email, phone, password) VALUES (?, ?, ?, ?)";
+        "INSERT INTO users (name, email, phone, password, promo, status, address) VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String UPDATE =
+        "UPDATE users SET name=?, phone=?, password=?, promo=?, status=?, address=? WHERE id=?";
 
     private static final String SELECT_BY_EMAIL =
         "SELECT * FROM users WHERE email = ?";
@@ -38,6 +41,9 @@ public class UserRepository {
             ps.setString(2, user.getEmail());
             ps.setString(3, user.getPhone());
             ps.setString(4, user.getPassword());
+            ps.setBoolean(5, user.isPromo());
+            ps.setString(6, user.getStatus());
+            ps.setString(7, user.getAddress());
             ps.executeUpdate();
 
            try (ResultSet rs = ps.getGeneratedKeys()) {
@@ -84,6 +90,25 @@ public class UserRepository {
     }
 
     /**
+     * Update an existing user.
+     * @param user the user with updated fields
+     * @throws SQLException on error
+     */
+    public void update(User user) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(UPDATE)) {
+            ps.setString(1, user.getName());
+            ps.setString(2, user.getPhone());
+            ps.setString(3, user.getPassword());
+            ps.setBoolean(4, user.isPromo());
+            ps.setString(5, user.getStatus());
+            ps.setString(6, user.getAddress());
+            ps.setLong(7, user.getId());
+            ps.executeUpdate();
+        }
+    }
+
+    /**
      * Map a ResultSet row to a User object.
      * @param rs the ResultSet containing user data
      * @return a User object populated with data from the ResultSet
@@ -96,6 +121,9 @@ public class UserRepository {
         u.setEmail(rs.getString("email"));
         u.setPhone(rs.getString("phone"));
         u.setPassword(rs.getString("password"));
+        u.setPromo(rs.getBoolean("promo"));
+        u.setStatus(rs.getString("status"));
+        u.setAddress(rs.getString("address"));
         return u;
     }
 }

--- a/backend/src/main/resources/application.properties~
+++ b/backend/src/main/resources/application.properties~
@@ -1,1 +1,0 @@
-spring.application.name=team17bookstore

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -1,0 +1,39 @@
+-- Basic schema for the bookstore application
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    phone VARCHAR(50),
+    password VARCHAR(255) NOT NULL,
+    promo BOOLEAN DEFAULT FALSE,
+    status VARCHAR(20),
+    address VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS books (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    author VARCHAR(255),
+    isbn VARCHAR(50),
+    category VARCHAR(100),
+    buying_price DOUBLE,
+    selling_price DOUBLE,
+    cover_image_url VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_email VARCHAR(255) NOT NULL,
+    address VARCHAR(255),
+    payment_method VARCHAR(100),
+    total DOUBLE
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    order_id BIGINT NOT NULL,
+    book_id BIGINT NOT NULL,
+    quantity INT NOT NULL,
+    price DOUBLE,
+    FOREIGN KEY (order_id) REFERENCES orders(id)
+);

--- a/backend/src/test/java/com/bookstore/team17bookstore/BookServiceTests.java
+++ b/backend/src/test/java/com/bookstore/team17bookstore/BookServiceTests.java
@@ -1,0 +1,28 @@
+package com.bookstore.team17bookstore;
+
+import com.bookstore.team17bookstore.model.Book;
+import com.bookstore.team17bookstore.service.BookService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class BookServiceTests {
+    @Autowired
+    private BookService bookService;
+
+    @Test
+    void addAndFindBook() throws Exception {
+        Book b = new Book();
+        b.setTitle("test");
+        b.setAuthor("author");
+        b.setIsbn("123");
+        bookService.add(b);
+
+        assertThat(bookService.findByISBN("123").isPresent()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/bookstore/team17bookstore/UserServiceTests.java
+++ b/backend/src/test/java/com/bookstore/team17bookstore/UserServiceTests.java
@@ -1,0 +1,40 @@
+package com.bookstore.team17bookstore;
+
+import com.bookstore.team17bookstore.model.User;
+import com.bookstore.team17bookstore.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class UserServiceTests {
+    @Autowired
+    private UserService userService;
+
+    @Test
+    void registerAndVerify() throws Exception {
+        User u = new User("Test","test@example.com","","secret");
+        u.setAddress("123 Main");
+        u.setStatus("ACTIVE");
+        userService.register(u);
+
+        assertThat(userService.verifyCredentials("test@example.com","secret")).isTrue();
+    }
+
+    @Test
+    void updateProfile() throws Exception {
+        User u = new User("T","u@example.com","","pass");
+        u.setAddress("123");
+        u.setStatus("ACTIVE");
+        userService.register(u);
+        Long id = userService.idByEmail("u@example.com");
+        u.setId(id);
+        u.setName("Updated");
+        userService.update(u);
+        assertThat(userService.findById(id).get().getName()).isEqualTo("Updated");
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.sql.init.mode=always

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080

--- a/frontend/src/app/account/page.jsx
+++ b/frontend/src/app/account/page.jsx
@@ -1,53 +1,60 @@
 // ACCOUNT PROFILE PAGE
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Head from 'next/head';
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
 export default function Page() {
-    // dummy profile info
-    const [fullName, setFullName] = useState('Jen Chen');
-    const [email, setEmail] = useState('jdc0226@gmail.com');
-    const [confirmEmail, setConfirmEmail] = useState('');
+    const [fullName, setFullName] = useState('');
+    const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [profilePic, setProfilePic] = useState('https://t4.ftcdn.net/jpg/02/15/84/43/360_F_215844325_ttX9YiIIyeaR7Ne6EaLLjMAmy4GvPC69.jpg');
-
+    const [promo, setPromo] = useState(false);
     const [uploading, setUploading] = useState(false);
-
-    const [confirmEmailError, setConfirmEmailError] = useState(false);
     const [passwordError, setPasswordError] = useState(false);
-
-    const [cardNumber, setCardNumber] = useState('');
     const [address, setAddress] = useState('');
 
-    // dummy displayed info (left card)
-    const [displayFullName, setDisplayFullName] = useState(fullName);
+    const [displayFullName, setDisplayFullName] = useState('');
+    const userId = typeof window !== 'undefined' ? localStorage.getItem('userId') : null;
 
-    const handleUpdate = (event) => {
+    useEffect(() => {
+        if (!userId) return;
+        fetch(`${API_BASE}/users/${userId}`)
+            .then((r) => r.json())
+            .then((data) => {
+                setFullName(data.name);
+                setEmail(data.email);
+                setPromo(data.promo);
+                setAddress(data.address || '');
+                setDisplayFullName(data.name);
+            });
+    }, [userId]);
+
+    const handleUpdate = async (event) => {
         event.preventDefault();
-
-        let hasError = false;
-
-        if (confirmEmail !== email) {
-            setConfirmEmailError(true);
-            hasError = true;
-        } else {
-            setConfirmEmailError(false);
-        }
 
         if (password.trim() === '') {
             setPasswordError(true);
-            hasError = true;
-        } else {
-            setPasswordError(false);
+            return;
         }
+        setPasswordError(false);
 
-        if (hasError) return;
-
-        // mimic successful update
+        const body = {
+            name: fullName,
+            phone: '',
+            password,
+            promo,
+            status: 'ACTIVE',
+            address,
+        };
+        await fetch(`${API_BASE}/users/${userId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
         setDisplayFullName(fullName);
-        alert('Profile updated (dummy save)!');
         setPassword('');
-        setConfirmEmail('');
     };
 
     const handleImageChange = (event) => {
@@ -123,20 +130,6 @@ export default function Page() {
                         style={inputStyle}
                     />
                     <input
-                        type="email"
-                        placeholder="Confirm Email"
-                        value={confirmEmail}
-                        onChange={(e) => setConfirmEmail(e.target.value)}
-                        className="text-black"
-                        style={{
-                            ...inputStyle,
-                            borderColor: confirmEmailError ? 'red' : inputStyle.borderColor,
-                        }}
-                    />
-                    {confirmEmailError && (
-                        <div style={errorTextStyle}>Emails must match</div>
-                    )}
-                    <input
                         type="password"
                         placeholder="Password"
                         value={password}
@@ -150,17 +143,14 @@ export default function Page() {
                     {passwordError && (
                         <div style={errorTextStyle}>Password required</div>
                     )}
-                    <input
-                        type="card info"
-                        placeholder="Card Info"
-                        value={cardNumber}
-                        onChange={(e) => setCardNumber(e.target.value)}
-                        className="text-black"
-                        style={{
-                            ...inputStyle,
-                            borderColor: passwordError ? 'red' : inputStyle.borderColor,
-                        }}
-                    />
+                    <label className="text-white flex gap-2 mt-2">
+                        <input
+                            type="checkbox"
+                            checked={promo}
+                            onChange={(e) => setPromo(e.target.checked)}
+                        />
+                        Receive promotions
+                    </label>
                     <input
                         type="address"
                         placeholder="Address"

--- a/frontend/src/app/cart/page.jsx
+++ b/frontend/src/app/cart/page.jsx
@@ -23,12 +23,10 @@ export default function CartPage() {
 
     return (
         <>
-            return (
-            <>
-                {cartItems.length === 0 ? ( // for if nothing in cart
-                    <div style={pageStyle}>
-                        <div style={cardStyle}>
-                            <h1 style={titleStyle}>Your Cart is Empty</h1>
+            {cartItems.length === 0 ? ( // for if nothing in cart
+                <div style={pageStyle}>
+                    <div style={cardStyle}>
+                        <h1 style={titleStyle}>Your Cart is Empty</h1>
                             <p style={messageStyle}>
                                 Looks like you haven’t added any books yet. Start exploring to find your next favorite read!
                             </p>
@@ -100,8 +98,6 @@ export default function CartPage() {
                         />
                     </div>
                 )}
-            </>
-            );
         </>
     );
 }

--- a/frontend/src/app/page.jsx
+++ b/frontend/src/app/page.jsx
@@ -14,7 +14,7 @@ export default function Home() {
     const router = useRouter();
 
     useEffect(() => {
-        fetch('http://localhost:8080/books')
+        fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/books`)
             .then(response => response.json())
             .then(data => setTopSellers(data))
             .catch(error => console.error('Error fetching books:', error));

--- a/frontend/src/app/search/page.jsx
+++ b/frontend/src/app/search/page.jsx
@@ -19,7 +19,7 @@ export default function SearchPage() {
         setSearchTerm(term);
         setSearchType(type);
 
-        fetch('http://localhost:8080/books')
+        fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/books`)
             .then((response) => response.json())
             .then((data) => {
                 let filtered = data;

--- a/frontend/src/components/ComingSoon.jsx
+++ b/frontend/src/components/ComingSoon.jsx
@@ -7,7 +7,7 @@ export default function ComingSoon() {
 
     // fetch books, currently by id
     useEffect(() => {
-        fetch("http://localhost:8080/books")
+        fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/books`)
             .then((res) => res.json())
             .then((data) => {
                 const comingSoon = data.filter((book) =>
@@ -50,7 +50,7 @@ export default function ComingSoon() {
                                 </h3>
                                 <p className="text-gray-300 text-sm">{book.author}</p>
                                 <p className="text-red-300 text-sm mt-2">
-                                    ${book.price?.toFixed(2)}
+                                    ${book.buyingPrice?.toFixed(2)}
                                 </p>
                             </div>
                         </div>

--- a/frontend/src/components/LoginModal.jsx
+++ b/frontend/src/components/LoginModal.jsx
@@ -1,9 +1,13 @@
 // LOGIN POPUP
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 export default function LoginModal({ show, onClose, setAuthenticated, setUserProfile }) {
+    const [message, setMessage] = useState(null);
+    const [remember, setRemember] = useState(false);
     useEffect(() => {
         if (show) document.body.style.overflow = 'hidden';
         else document.body.style.overflow = 'auto';
@@ -23,14 +27,30 @@ export default function LoginModal({ show, onClose, setAuthenticated, setUserPro
                 <h2 className="text-lg font-semibold mb-4 text-white">Login</h2>
                 <form
                     className="flex flex-col gap-3"
-                    onSubmit={(e) => {
+                    onSubmit={async (e) => {
                         e.preventDefault();
-                        setAuthenticated(true);
-                        setUserProfile({
-                            fullName: e.target.email.value,
-                            _id: "dummy-id",
-                        });
-                        onClose();
+                        const body = new URLSearchParams();
+                        body.append('email', e.target.email.value);
+                        body.append('password', e.target.password.value);
+                        try {
+                            const resp = await fetch(`${API_BASE}/users/login`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                                body: body.toString(),
+                            });
+                            if (!resp.ok) throw new Error('Login failed');
+                            const data = await resp.json();
+                            setAuthenticated(true);
+                            setUserProfile({ fullName: data.name, _id: data.id });
+                            if (remember) {
+                                localStorage.setItem('token', data.token);
+                                localStorage.setItem('userId', data.id);
+                            }
+                            setMessage(null);
+                            onClose();
+                        } catch (err) {
+                            setMessage('Invalid credentials');
+                        }
                     }}
                 >
                     <div>
@@ -49,13 +69,28 @@ export default function LoginModal({ show, onClose, setAuthenticated, setUserPro
                             className="w-full border px-2 py-1 rounded text-white"
                         />
                     </div>
+                    <label className="text-white flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            name="remember"
+                            checked={remember}
+                            onChange={(e) => setRemember(e.target.checked)}
+                        />
+                        Remember me
+                    </label>
                     <button
                         type="submit"
                         className="bg-red-900 text-white px-4 py-2 rounded hover:bg-[oklch(60%_0.177_26.899)]"
                     >
                         Submit
                     </button>
+                    {message && (
+                        <p className="text-white text-sm">{message}</p>
+                    )}
                 </form>
+                <p className="text-white text-sm mt-2">
+                    Don't have an account? <a href="#" onClick={onClose}>Sign up</a>
+                </p>
                 <button
                     onClick={onClose}
                     className="absolute top-2 right-2 text-gray-500 hover:text-black"

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -16,6 +16,17 @@ export default function Navbar() {
     {/* global thing for cart tracking */}
     const [cartItems, setCartItems] = useState([]);
 
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        const id = localStorage.getItem('userId');
+        if (token && id) {
+            setAuthenticated(true);
+            fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/users/${id}`)
+                .then((r) => r.json())
+                .then((data) => setUserProfile({ fullName: data.name, _id: id }));
+        }
+    }, []);
+
     // dropdown logic
     useEffect(() => {
         const handleClickOutside = (event) => {
@@ -90,6 +101,9 @@ export default function Navbar() {
                                         
                                         <button
                                             onClick={() => {
+                                                fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/users/logout`, { method: 'POST' });
+                                                localStorage.removeItem('token');
+                                                localStorage.removeItem('userId');
                                                 setAuthenticated(false);
                                                 setUserProfile(null);
                                                 setDropdownOpen(false);

--- a/frontend/src/components/SignupModal.jsx
+++ b/frontend/src/components/SignupModal.jsx
@@ -1,9 +1,12 @@
 // SIGNUP POPUP
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 export default function SignupModal({ show, onClose }) {
+    const [message, setMessage] = useState(null);
     useEffect(() => {
         if (show) document.body.style.overflow = 'hidden';
         else document.body.style.overflow = 'auto';
@@ -23,14 +26,27 @@ export default function SignupModal({ show, onClose }) {
                 <h2 className="text-lg font-semibold mb-4 text-white">Signup</h2>
                 <form
                     className="flex flex-col gap-3"
-                    onSubmit={(e) => {
+                    onSubmit={async (e) => {
                         e.preventDefault();
-                        const name = e.target.name.value;
-                        const email = e.target.email.value;
-                        const phone = e.target.phone.value;
-                        const password = e.target.password.value;
-
-                        console.log("Signup submitted:", { name, email, phone, password });
+                        const body = {
+                            name: e.target.name.value,
+                            email: e.target.email.value,
+                            phone: e.target.phone.value,
+                            password: e.target.password.value,
+                            promo: e.target.promo.checked,
+                        };
+                        try {
+                            const resp = await fetch(`${API_BASE}/users/register`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify(body),
+                            });
+                            if (!resp.ok) throw new Error('Registration failed');
+                            setMessage('Registration successful');
+                            e.target.reset();
+                        } catch (err) {
+                            setMessage('Error registering user');
+                        }
                     }}
                 >
                     <div>
@@ -65,12 +81,19 @@ export default function SignupModal({ show, onClose }) {
                             className="w-full border px-2 py-1 rounded text-white"
                         />
                     </div>
+                    <label className="text-white flex items-center gap-2">
+                        <input type="checkbox" name="promo" />
+                        Sign me up for promotions
+                    </label>
                     <button
                         type="submit"
                         className="bg-red-900 text-white px-4 py-2 rounded hover:bg-[oklch(60%_0.177_26.899)]"
                     >
                         Submit
                     </button>
+                    {message && (
+                        <p className="text-white text-sm">{message}</p>
+                    )}
                 </form>
                 <button
                     onClick={onClose}

--- a/frontend/src/components/TopSellers.jsx
+++ b/frontend/src/components/TopSellers.jsx
@@ -7,7 +7,7 @@ export default function TopSellers() {
     const [topSellers, setTopSellers] = useState([]);
 
     useEffect(() => {
-        fetch("http://localhost:8080/books")
+        fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/books`)
             .then((res) => res.json())
             .then((data) => {
                 const topSellers = data.filter((book) => [6, 7, 8].includes(book.id));
@@ -50,7 +50,7 @@ export default function TopSellers() {
                                     </h3>
                                     <p className="text-gray-300 text-sm">{book.author}</p>
                                     <p className="text-red-300 text-sm mt-2">
-                                        ${book.price?.toFixed(2)}
+                                        ${book.buyingPrice?.toFixed(2)}
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add address field to user model and SQL schema
- expose endpoints to get user by id or email
- return id and name from login endpoint
- update repository to handle address field
- connect login modal and navbar to authentication APIs
- enable editing profile data from account page

## Testing
- ❌ `mvn test` *(failed: command not found)*
- ❌ `npm test` *(failed: missing script)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687f0468cd048321a0caf11a381ea5d4